### PR TITLE
Adding new button device to IO module

### DIFF
--- a/doc/IO_module_doc.md
+++ b/doc/IO_module_doc.md
@@ -142,6 +142,20 @@ Status will be forwarded to the external app when:
 Status will be forwarded to the external app when:
  - there is a difference between the previous and current status (e.g. output has been turned on; state of any input has changed)
 
+### Button
+
+Simple general button representation. The input is true when button is not pressed and false when button is pressed.
+
+#### Device specs
+ - input count : 1
+ - output count: 0
+ - no button (buttonPresses always 0) - button functionality is forwarded via input
+
+#### Status forwarding
+
+Status will be forwarded to the external app when:
+ - there is a difference between the previous and current status (e.g. output has been turned on; state of any input has changed)
+
 ## Behaviour in External server
 
 The IO module in External server uses [this HTTP Api](https://github.com/bringauto/fleet-http-client) to communicate with some external app. The statuses are sent to the external app and the commands are received from it. The HTTP Api connection credentials must be forwarded to IO module config. The credentials in External server's config could look like this:

--- a/include/bringauto/modules/io_module/devices/button/button_module_manager.hpp
+++ b/include/bringauto/modules/io_module/devices/button/button_module_manager.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <fleet_protocol/common_headers/memory_management.h>
+
+namespace bringauto::modules::io_module::devices::button {
+
+// These functions are implementing function defined in module_manager.h specifically for Arduino Uno device
+
+int button_send_status_condition(const buffer current_status, const buffer new_status);
+
+int button_generate_command(buffer *generated_command, const buffer new_status, const buffer current_status, const buffer current_command);
+
+int button_aggregate_status(buffer *aggregated_status, const buffer current_status, const buffer new_status);
+
+int button_aggregate_error(buffer *error_message, const buffer current_error_message, const buffer status);
+
+int button_generate_first_command(buffer *default_command);
+
+int button_status_data_valid(const buffer status);
+
+int button_command_data_valid(const buffer command);
+
+}

--- a/include/bringauto/modules/io_module/io_module.h
+++ b/include/bringauto/modules/io_module/io_module.h
@@ -32,6 +32,15 @@ static const int ARDUINO_UNO_INPUTS_COUNT = 6;
 /// @brief Number of outputs on Arduino Uno
 static const int ARDUINO_UNO_OUTPUTS_COUNT = 7;
 
+// Button specific values
+
+/// @brief Button identification as described in Fleet protocol
+static const int BUTTON_DEVICE_TYPE = 4;
+/// @brief Number of inputs on Button
+static const int BUTTON_INPUTS_COUNT = 1;
+/// @brief Number of outputs on Button
+static const int BUTTON_OUTPUTS_COUNT = 0;
+
 /// @brief Indexes of outputs
 enum OutputIndexes { OUTPUT_1, OUTPUT_2, OUTPUT_3, OUTPUT_4, OUTPUT_5, OUTPUT_6, OUTPUT_7, OUTPUT_8,
                      OUTPUT_9, OUTPUT_10, OUTPUT_11, OUTPUT_12, OUTPUT_13, OUTPUT_14, OUTPUT_15, OUTPUT_16 };

--- a/source/bringauto/modules/devices/arduino_opta/arduino_opta_module_manager.cpp
+++ b/source/bringauto/modules/devices/arduino_opta/arduino_opta_module_manager.cpp
@@ -39,7 +39,8 @@ int arduino_opta_send_status_condition(const buffer current_status, const buffer
     return CONDITION_NOT_MET;
 }
 
-int arduino_opta_generate_command(buffer *generated_command, const buffer new_status, const buffer current_status, const buffer current_command) {
+int arduino_opta_generate_command(buffer *generated_command, const buffer new_status, const buffer current_status,
+                                  const buffer current_command) {
     if(allocate(generated_command, current_command.size_in_bytes) ==  NOT_OK) {
         return NOT_OK;
     }

--- a/source/bringauto/modules/devices/arduino_uno/arduino_uno_module_manager.cpp
+++ b/source/bringauto/modules/devices/arduino_uno/arduino_uno_module_manager.cpp
@@ -6,7 +6,7 @@
 
 namespace bringauto::modules::io_module::devices::arduino_uno {
 
-int arduino_uno_send_status_condition(const buffer current_status, const buffer new_status){
+int arduino_uno_send_status_condition(const buffer current_status, const buffer new_status) {
     bringauto::io_module_utils::DeviceStatus<bringauto::modules::io_module::ARDUINO_UNO_INPUTS_COUNT,
                                              bringauto::modules::io_module::ARDUINO_UNO_OUTPUTS_COUNT> c_status;
 
@@ -36,7 +36,8 @@ int arduino_uno_send_status_condition(const buffer current_status, const buffer 
     return CONDITION_NOT_MET;
 }
 
-int arduino_uno_generate_command(buffer *generated_command, const buffer new_status, const buffer current_status, const buffer current_command){
+int arduino_uno_generate_command(buffer *generated_command, const buffer new_status, const buffer current_status,
+                                const buffer current_command) {
     if(allocate(generated_command, current_command.size_in_bytes) ==  NOT_OK) {
         return NOT_OK;
     }
@@ -44,7 +45,7 @@ int arduino_uno_generate_command(buffer *generated_command, const buffer new_sta
     return OK;
 }
 
-int arduino_uno_aggregate_status(buffer *aggregated_status, const buffer current_status, const buffer new_status){
+int arduino_uno_aggregate_status(buffer *aggregated_status, const buffer current_status, const buffer new_status) {
     bringauto::io_module_utils::DeviceStatus<bringauto::modules::io_module::ARDUINO_UNO_INPUTS_COUNT,
                                              bringauto::modules::io_module::ARDUINO_UNO_OUTPUTS_COUNT> status;
 
@@ -57,7 +58,7 @@ int arduino_uno_aggregate_status(buffer *aggregated_status, const buffer current
     return status.serializeToBuffer(aggregated_status);
 }
 
-int arduino_uno_aggregate_error(buffer *error_message, const buffer current_error_message, const buffer status){
+int arduino_uno_aggregate_error(buffer *error_message, const buffer current_error_message, const buffer status) {
     if(current_error_message.data == nullptr){ // In this case, there is no current error message in error aggregator - creating default error
         bringauto::io_module_utils::DeviceStatus<bringauto::modules::io_module::ARDUINO_UNO_INPUTS_COUNT,
                                              bringauto::modules::io_module::ARDUINO_UNO_OUTPUTS_COUNT> status_object;
@@ -83,7 +84,7 @@ int arduino_uno_aggregate_error(buffer *error_message, const buffer current_erro
     return bringauto::io_module_utils::SerializationUtils::serialize_error(error_message, aggregated_button_presses + status_object.getButtonPresses());
 }
 
-int arduino_uno_generate_first_command(buffer *default_command){
+int arduino_uno_generate_first_command(buffer *default_command) {
     bringauto::io_module_utils::DeviceCommand command;
     for(int i = bringauto::modules::io_module::OutputIndexes::OUTPUT_1; i <= bringauto::modules::io_module::OutputIndexes::OUTPUT_4; i++) {
         command.addOutputAction(bringauto::io_module_utils::OutputAction(i, bringauto::io_module_utils::ActionType::SET_OFF));
@@ -96,14 +97,14 @@ int arduino_uno_generate_first_command(buffer *default_command){
     return OK;
 }
 
-int arduino_uno_status_data_valid(const buffer status){
+int arduino_uno_status_data_valid(const buffer status) {
     bringauto::io_module_utils::DeviceStatus<bringauto::modules::io_module::ARDUINO_UNO_INPUTS_COUNT,
                                              bringauto::modules::io_module::ARDUINO_UNO_OUTPUTS_COUNT> status_object;
 
     return status_object.deserializeFromBuffer(status);
 }
 
-int arduino_uno_command_data_valid(const buffer command){
+int arduino_uno_command_data_valid(const buffer command) {
     bringauto::io_module_utils::DeviceCommand command_object;
 
     return command_object.deserializeFromBuffer(command);

--- a/source/bringauto/modules/devices/button/button_module_manager.cpp
+++ b/source/bringauto/modules/devices/button/button_module_manager.cpp
@@ -1,0 +1,103 @@
+#include <bringauto/modules/io_module/devices/button/button_module_manager.hpp>
+#include <fleet_protocol/module_maintainer/module_gateway/module_manager.h>
+#include <bringauto/modules/io_module/io_module.h>
+#include <bringauto/io_module_utils/DeviceStatus.hpp>
+#include <bringauto/io_module_utils/DeviceCommand.hpp>
+
+namespace bringauto::modules::io_module::devices::button {
+
+int button_send_status_condition(const buffer current_status, const buffer new_status){
+    bringauto::io_module_utils::DeviceStatus<bringauto::modules::io_module::BUTTON_INPUTS_COUNT,
+                                             bringauto::modules::io_module::BUTTON_OUTPUTS_COUNT> c_status;
+
+    int rc1 = c_status.deserializeFromBuffer(current_status);
+
+    bringauto::io_module_utils::DeviceStatus<bringauto::modules::io_module::BUTTON_INPUTS_COUNT,
+                                             bringauto::modules::io_module::BUTTON_OUTPUTS_COUNT> n_status;
+
+    int rc2 = n_status.deserializeFromBuffer(new_status);
+
+    if(rc1 == NOT_OK || rc2 == NOT_OK) {
+        return NOT_OK;
+    }
+
+    for(int i = 0; i < c_status.getInputStates().size(); i++) {
+        if(c_status.getInputStates()[i] != n_status.getInputStates()[i]) {
+            return OK;
+        }
+    }
+
+    return CONDITION_NOT_MET;
+}
+
+int button_generate_command(buffer *generated_command, const buffer new_status, const buffer current_status, const buffer current_command){
+    if(allocate(generated_command, current_command.size_in_bytes) ==  NOT_OK) {
+        return NOT_OK;
+    }
+    std::memcpy(generated_command->data, current_command.data, generated_command->size_in_bytes);
+    return OK;
+}
+
+int button_aggregate_status(buffer *aggregated_status, const buffer current_status, const buffer new_status){
+    bringauto::io_module_utils::DeviceStatus<bringauto::modules::io_module::BUTTON_INPUTS_COUNT,
+                                             bringauto::modules::io_module::BUTTON_OUTPUTS_COUNT> status;
+
+    int rc = status.deserializeFromBuffer(new_status);
+
+    if(rc == NOT_OK) {
+        return NOT_OK;
+    }
+
+    return status.serializeToBuffer(aggregated_status);
+}
+
+int button_aggregate_error(buffer *error_message, const buffer current_error_message, const buffer status){
+    if(current_error_message.data == nullptr){ // In this case, there is no current error message in error aggregator - creating default error
+        bringauto::io_module_utils::DeviceStatus<bringauto::modules::io_module::BUTTON_INPUTS_COUNT,
+                                             bringauto::modules::io_module::BUTTON_OUTPUTS_COUNT> status_object;
+
+        int rc = status_object.deserializeFromBuffer(status);
+        if(rc == NOT_OK) {
+            return NOT_OK;
+        }
+        return bringauto::io_module_utils::SerializationUtils::serialize_error(error_message, status_object.getButtonPresses());
+    }
+
+    int aggregated_button_presses = bringauto::io_module_utils::SerializationUtils::deserialize_error(static_cast<char*> (current_error_message.data), current_error_message.size_in_bytes);
+
+    bringauto::io_module_utils::DeviceStatus<bringauto::modules::io_module::BUTTON_INPUTS_COUNT,
+                                             bringauto::modules::io_module::BUTTON_OUTPUTS_COUNT> status_object;
+
+    int rc = status_object.deserializeFromBuffer(status);
+
+    if(aggregated_button_presses < 0 || rc == NOT_OK) {
+        return NOT_OK;
+    }
+
+    return bringauto::io_module_utils::SerializationUtils::serialize_error(error_message, aggregated_button_presses + status_object.getButtonPresses());
+}
+
+int button_generate_first_command(buffer *default_command){
+    bringauto::io_module_utils::DeviceCommand command;
+
+    if(command.serializeToBuffer(default_command) == NOT_OK) {
+        return NOT_OK;
+    }
+
+    return OK;
+}
+
+int button_status_data_valid(const buffer status){
+    bringauto::io_module_utils::DeviceStatus<bringauto::modules::io_module::BUTTON_INPUTS_COUNT,
+                                             bringauto::modules::io_module::BUTTON_OUTPUTS_COUNT> status_object;
+
+    return status_object.deserializeFromBuffer(status);
+}
+
+int button_command_data_valid(const buffer command){
+    bringauto::io_module_utils::DeviceCommand command_object;
+
+    return command_object.deserializeFromBuffer(command);
+}
+
+}

--- a/source/bringauto/modules/devices/button/button_module_manager.cpp
+++ b/source/bringauto/modules/devices/button/button_module_manager.cpp
@@ -6,7 +6,7 @@
 
 namespace bringauto::modules::io_module::devices::button {
 
-int button_send_status_condition(const buffer current_status, const buffer new_status){
+int button_send_status_condition(const buffer current_status, const buffer new_status) {
     bringauto::io_module_utils::DeviceStatus<bringauto::modules::io_module::BUTTON_INPUTS_COUNT,
                                              bringauto::modules::io_module::BUTTON_OUTPUTS_COUNT> c_status;
 
@@ -30,7 +30,8 @@ int button_send_status_condition(const buffer current_status, const buffer new_s
     return CONDITION_NOT_MET;
 }
 
-int button_generate_command(buffer *generated_command, const buffer new_status, const buffer current_status, const buffer current_command){
+int button_generate_command(buffer *generated_command, const buffer new_status, const buffer current_status,
+                            const buffer current_command) {
     if(allocate(generated_command, current_command.size_in_bytes) ==  NOT_OK) {
         return NOT_OK;
     }
@@ -51,11 +52,11 @@ int button_aggregate_status(buffer *aggregated_status, const buffer current_stat
     return status.serializeToBuffer(aggregated_status);
 }
 
-int button_aggregate_error(buffer *error_message, const buffer current_error_message, const buffer status){
+int button_aggregate_error(buffer *error_message, const buffer current_error_message, const buffer status) {
     return bringauto::io_module_utils::SerializationUtils::serialize_error(error_message, 0);
 }
 
-int button_generate_first_command(buffer *default_command){
+int button_generate_first_command(buffer *default_command) {
     bringauto::io_module_utils::DeviceCommand command;
 
     if(command.serializeToBuffer(default_command) == NOT_OK) {
@@ -65,14 +66,14 @@ int button_generate_first_command(buffer *default_command){
     return OK;
 }
 
-int button_status_data_valid(const buffer status){
+int button_status_data_valid(const buffer status) {
     bringauto::io_module_utils::DeviceStatus<bringauto::modules::io_module::BUTTON_INPUTS_COUNT,
                                              bringauto::modules::io_module::BUTTON_OUTPUTS_COUNT> status_object;
 
     return status_object.deserializeFromBuffer(status);
 }
 
-int button_command_data_valid(const buffer command){
+int button_command_data_valid(const buffer command) {
     bringauto::io_module_utils::DeviceCommand command_object;
 
     return command_object.deserializeFromBuffer(command);

--- a/source/bringauto/modules/devices/button/button_module_manager.cpp
+++ b/source/bringauto/modules/devices/button/button_module_manager.cpp
@@ -52,29 +52,7 @@ int button_aggregate_status(buffer *aggregated_status, const buffer current_stat
 }
 
 int button_aggregate_error(buffer *error_message, const buffer current_error_message, const buffer status){
-    if(current_error_message.data == nullptr){ // In this case, there is no current error message in error aggregator - creating default error
-        bringauto::io_module_utils::DeviceStatus<bringauto::modules::io_module::BUTTON_INPUTS_COUNT,
-                                             bringauto::modules::io_module::BUTTON_OUTPUTS_COUNT> status_object;
-
-        int rc = status_object.deserializeFromBuffer(status);
-        if(rc == NOT_OK) {
-            return NOT_OK;
-        }
-        return bringauto::io_module_utils::SerializationUtils::serialize_error(error_message, status_object.getButtonPresses());
-    }
-
-    int aggregated_button_presses = bringauto::io_module_utils::SerializationUtils::deserialize_error(static_cast<char*> (current_error_message.data), current_error_message.size_in_bytes);
-
-    bringauto::io_module_utils::DeviceStatus<bringauto::modules::io_module::BUTTON_INPUTS_COUNT,
-                                             bringauto::modules::io_module::BUTTON_OUTPUTS_COUNT> status_object;
-
-    int rc = status_object.deserializeFromBuffer(status);
-
-    if(aggregated_button_presses < 0 || rc == NOT_OK) {
-        return NOT_OK;
-    }
-
-    return bringauto::io_module_utils::SerializationUtils::serialize_error(error_message, aggregated_button_presses + status_object.getButtonPresses());
+    return bringauto::io_module_utils::SerializationUtils::serialize_error(error_message, 0);
 }
 
 int button_generate_first_command(buffer *default_command){

--- a/source/device_management.cpp
+++ b/source/device_management.cpp
@@ -9,6 +9,7 @@ int is_device_type_supported(unsigned int device_type) {
         case bringauto::modules::io_module::ARDUINO_OPTA_DEVICE_TYPE:
         case bringauto::modules::io_module::ARDUINO_MEGA_DEVICE_TYPE:
         case bringauto::modules::io_module::ARDUINO_UNO_DEVICE_TYPE:
+        case bringauto::modules::io_module::BUTTON_DEVICE_TYPE:
             return OK;
         default:
             return NOT_OK;

--- a/source/module_manager.cpp
+++ b/source/module_manager.cpp
@@ -6,6 +6,7 @@
 #include <bringauto/modules/io_module/devices/arduino_opta/arduino_opta_module_manager.hpp>
 #include <bringauto/modules/io_module/devices/arduino_mega/arduino_mega_module_manager.hpp>
 #include <bringauto/modules/io_module/devices/arduino_uno/arduino_uno_module_manager.hpp>
+#include <bringauto/modules/io_module/devices/button/button_module_manager.hpp>
 
 #include <cstring>
 
@@ -17,6 +18,8 @@ int send_status_condition(const buffer current_status, const buffer new_status, 
             return bringauto::modules::io_module::devices::arduino_mega::arduino_mega_send_status_condition(current_status, new_status);
         case bringauto::modules::io_module::ARDUINO_UNO_DEVICE_TYPE:
             return bringauto::modules::io_module::devices::arduino_uno::arduino_uno_send_status_condition(current_status, new_status);
+        case bringauto::modules::io_module::BUTTON_DEVICE_TYPE:
+            return bringauto::modules::io_module::devices::button::button_send_status_condition(current_status, new_status);
         default:
             return NOT_OK;
     }
@@ -30,6 +33,8 @@ int generate_command(buffer *generated_command, const buffer new_status, const b
             return bringauto::modules::io_module::devices::arduino_mega::arduino_mega_generate_command(generated_command, new_status, current_status, current_command);
         case bringauto::modules::io_module::ARDUINO_UNO_DEVICE_TYPE:
             return bringauto::modules::io_module::devices::arduino_uno::arduino_uno_generate_command(generated_command, new_status, current_status, current_command);
+        case bringauto::modules::io_module::BUTTON_DEVICE_TYPE:
+            return bringauto::modules::io_module::devices::button::button_generate_command(generated_command, new_status, current_status, current_command);
         default:
             return NOT_OK;
     }
@@ -43,6 +48,8 @@ int aggregate_status(buffer *aggregated_status, const buffer current_status, con
             return bringauto::modules::io_module::devices::arduino_mega::arduino_mega_aggregate_status(aggregated_status, current_status, new_status);
         case bringauto::modules::io_module::ARDUINO_UNO_DEVICE_TYPE:
             return bringauto::modules::io_module::devices::arduino_uno::arduino_uno_aggregate_status(aggregated_status, current_status, new_status);
+        case bringauto::modules::io_module::BUTTON_DEVICE_TYPE:
+            return bringauto::modules::io_module::devices::button::button_aggregate_status(aggregated_status, current_status, new_status);
         default:
             return NOT_OK;
     }
@@ -56,6 +63,8 @@ int aggregate_error(buffer *error_message, const buffer current_error_message, c
             return bringauto::modules::io_module::devices::arduino_mega::arduino_mega_aggregate_error(error_message, current_error_message, status);
         case bringauto::modules::io_module::ARDUINO_UNO_DEVICE_TYPE:
             return bringauto::modules::io_module::devices::arduino_uno::arduino_uno_aggregate_error(error_message, current_error_message, status);
+        case bringauto::modules::io_module::BUTTON_DEVICE_TYPE:
+            return bringauto::modules::io_module::devices::button::button_aggregate_error(error_message, current_error_message, status);
         default:
             return NOT_OK;
     }
@@ -69,6 +78,8 @@ int generate_first_command(buffer *default_command, unsigned int device_type) {
             return bringauto::modules::io_module::devices::arduino_mega::arduino_mega_generate_first_command(default_command);
         case bringauto::modules::io_module::ARDUINO_UNO_DEVICE_TYPE:
             return bringauto::modules::io_module::devices::arduino_uno::arduino_uno_generate_first_command(default_command);
+        case bringauto::modules::io_module::BUTTON_DEVICE_TYPE:
+            return bringauto::modules::io_module::devices::button::button_generate_first_command(default_command);
         default:
             return NOT_OK;
     }
@@ -82,6 +93,8 @@ int status_data_valid(const buffer status, unsigned int device_type) {
             return bringauto::modules::io_module::devices::arduino_mega::arduino_mega_status_data_valid(status);
         case bringauto::modules::io_module::ARDUINO_UNO_DEVICE_TYPE:
             return bringauto::modules::io_module::devices::arduino_uno::arduino_uno_status_data_valid(status);
+        case bringauto::modules::io_module::BUTTON_DEVICE_TYPE:
+            return bringauto::modules::io_module::devices::button::button_status_data_valid(status);
         default:
             return NOT_OK;
     }
@@ -95,6 +108,8 @@ int command_data_valid(const buffer command, unsigned int device_type) {
             return bringauto::modules::io_module::devices::arduino_mega::arduino_mega_command_data_valid(command);
         case bringauto::modules::io_module::ARDUINO_UNO_DEVICE_TYPE:
             return bringauto::modules::io_module::devices::arduino_uno::arduino_uno_command_data_valid(command);
+        case bringauto::modules::io_module::BUTTON_DEVICE_TYPE:
+            return bringauto::modules::io_module::devices::button::button_command_data_valid(command);
         default:
             return NOT_OK;
     }


### PR DESCRIPTION
The new button device was added to IO module. This device has only one input for button in Status message. The Command message is empty. The device is described in doc/IO_module_doc.md.

Some formatting errors have been fixed in other files.