### PR TITLE
bump fleet-http-client to v2.0.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ FIND_PACKAGE(fleet-protocol-cxx-helpers-static 1.2.0 REQUIRED)
 FIND_PACKAGE(fleet-protocol-interface 2.0.0 REQUIRED)
 
 IF (FLEET_PROTOCOL_BUILD_EXTERNAL_SERVER)
-    FIND_PACKAGE(fleet-http-client-shared 2.0.1 REQUIRED)
+    FIND_PACKAGE(fleet-http-client-shared 2.0.2 REQUIRED)
     ### fleet-http-client dependencies
     FIND_PACKAGE(Boost CONFIG REQUIRED)
     FIND_PACKAGE(ZLIB REQUIRED)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -8,7 +8,7 @@ BA_PACKAGE_LIBRARY(aeron                    v1.48.6)
 BA_PACKAGE_LIBRARY(fleet-protocol-interface v2.0.0 NO_DEBUG ON)
 
 IF (FLEET_PROTOCOL_BUILD_EXTERNAL_SERVER)
-    BA_PACKAGE_LIBRARY(fleet-http-client-shared v2.0.1)
+    BA_PACKAGE_LIBRARY(fleet-http-client-shared v2.0.2)
     BA_PACKAGE_LIBRARY(boost                    v1.86.0)
     BA_PACKAGE_LIBRARY(cpprestsdk               v2.10.20)
 ENDIF ()


### PR DESCRIPTION
Update fleet-http-client-shared dependency to v2.0.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependency version for external server builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->